### PR TITLE
Fix docker image: Take branch rename into account

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -2,7 +2,9 @@ name: Docker
 
 on:
   push:
-    branches: master
+    branches:
+      - dev
+      - stable
     paths:
       - 'src/Impostor.Server/**'
       - 'src/Impostor.Shared/**'


### PR DESCRIPTION
### Description

Previous commit did not take into account that Impostor-Staging's main branch is not called master anymore, so it didn't run. This PR fixes this
<!--
Explain why you made these changes and the problem they're solving.
-->

### Test Plan

- Merge and hope it builds

